### PR TITLE
Textual relevance

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-__all__ = ["utils", "context", "dataset", "preprocess", "textual_relevance"]

--- a/src/textual_relevance.py
+++ b/src/textual_relevance.py
@@ -3,9 +3,6 @@ from scipy import spatial
 from sklearn.feature_extraction.text import TfidfVectorizer
 import gensim.downloader
 
-from dataset import DatasetLoader
-from preprocess import Preprocessor
-
 class TextualRelevance():
     def __init__(self, embedding_type, dataset = None, word2vec_type = 'word2vec-google-news-300'):
         """Perform textual relevance calculation


### PR DESCRIPTION
- ~Change to relative path import on some submodule files and add __init__.py to be able to import submodules~ (Revert to absolute path)
- Add textual relevance: complete algorithms with code and stringdoc documentation. The only improvement I can make on a future commit after the PR merge is improve the word match metrics by rescaling it between 0 and 1 instead of 0 and inf at the moment, I would need to read into the literature a little bit more. To test the code

To use the code, do the following:

Create a Jupyter Notebook ~at the project root folder directory~ in `src/`, and run the following

```python
from preprocess import Preprocessor
from dataset import DatasetLoader
from textual_relevance import TextualRelevance

pp = Preprocessor()
# Assuming that the dataset is saved in ./src
ds = DatasetLoader().load_fakenewsnet(drop_if_less_than_num_contexts=3)

df = ds.as_pandas()
df["content"] = df["content"].apply(pp.preprocess_and_tokenize)

tfidf = TextualRelevance('tfidf', df.content)
val = tfidf.cosine_dist(df['content'].iloc[0], [pp.preprocess_and_tokenize(df['ctx2_content'].iloc[0]), pp.preprocess_and_tokenize(df['ctx3_content'].iloc[0])])
print(val)
```