### PR TITLE
sentiment: Adds a basic sentiment extractor

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -27,6 +27,7 @@ sgmllib3k==1.0.0
 six==1.16.0
 smart-open==6.3.0
 soupsieve==2.4.1
+textblob==0.17.1
 tinysegmenter==0.3
 tldextract==3.4.4
 tqdm==4.65.0

--- a/src/sentiment.py
+++ b/src/sentiment.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+from textblob import TextBlob
+
+
+@dataclass
+class Sentiment:
+    """Value between -1 and 1 describing whether the document is positive or negative in emotion"""
+    avg_polarity: Optional[float] = None
+    """Value between 0 and 1 describing whether the document is
+    objective/factual* (0) or subjective/opinionated (1).
+    
+    *Note the "factual" here is a language feature that doesn't tell us whether
+    the document is real or fake news yet."""
+    avg_subjectivity: Optional[float] = None
+
+    def as_pandas(self, prefix):
+        p = self.avg_polarity if self.avg_polarity is not None else pd.NA
+        s = self.avg_subjectivity if self.avg_subjectivity is not None else pd.NA
+        return pd.Series((p, s),
+                         (f"{prefix}_polarity", f"{prefix}_subjectivity"))
+
+
+class TextBlobSentimentExtractor:
+    def __init__(self):
+        pass
+
+    def extract_sentiment_opt(self, input: Optional[str]) -> Optional[Sentiment]:
+        """Extracts the sentiment using the popular
+        [TextBlob](https://textblob.readthedocs.io/) Extractor. Can accept
+        optional values such as python None or pandas NaType
+
+        Args:
+            input (Optional[str]): The input to extract sentiment from
+
+        Returns:
+            Optional[Sentiment]: The sentiment of the text
+        """
+        if input is None:
+            return Sentiment()
+        if not isinstance(input, str) and pd.isnull(input):
+            return Sentiment()
+        return self.extract_sentiment(input)
+
+    def extract_sentiment(self, input: str) -> Sentiment:
+        """Extracts the sentiment using the popular [TextBlob](https://textblob.readthedocs.io/) Extractor.
+
+        Args:
+            input (str): The input to extract sentiment from
+
+        Returns:
+            Sentiment: The sentiment of the text
+        """
+        blob = TextBlob(input)
+        return Sentiment(
+            blob.sentiment.polarity,
+            blob.sentiment.subjectivity
+        )


### PR DESCRIPTION
I haven't really done any analysis yet whether the values are very useful for determining fake news or not.

# Example
Below code extracts the sentiments for all articles and appends them to the existing dataframe:
```py
ds = DatasetLoader()
sentiment = TextBlobSentimentExtractor()

df = ds.load_horne2017_fakenewsdata().as_pandas()
for input_key, prefix in [("content", "content"), ("ctx1_content", "ctx1"), ("ctx2_content", "ctx2"), ("ctx3_content", "ctx3")]:
    sentiment_df = df[input_key].apply(lambda x: sentiment.extract_sentiment_opt(x).as_pandas(prefix))
    df = pd.concat([df, sentiment_df], axis=1)

print(df)
```